### PR TITLE
Improve intro animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,9 @@
 </head>
 <body>
     <div id="intro-animation">
-        <img src="delosquedicen.gif" alt="Intro animation">
+        <div class="loader">
+            <img src="delosquedicen.gif" alt="Intro animation">
+        </div>
     </div>
     <header class="sticky-header">
 	<div class="squigly">
@@ -169,7 +171,7 @@
                 if (intro) {
                     intro.style.display = 'none';
                 }
-            }, 4000);
+            }, 1500);
         });
         let slideIndex = 1;
         showSlides(slideIndex);

--- a/style.css
+++ b/style.css
@@ -11,16 +11,44 @@ body, html {
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: #ffffff;
+    background-color: transparent;
     display: flex;
     justify-content: center;
     align-items: center;
     z-index: 2000;
 }
 
-#intro-animation img {
+#intro-animation .loader {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#intro-animation .loader::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 150px;
+    height: 150px;
+    margin-top: -75px;
+    margin-left: -75px;
+    border: 8px solid rgba(128, 0, 32, 0.3);
+    border-top-color: #800020;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+#intro-animation .loader img {
     max-width: 100%;
     max-height: 100%;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 header.sticky-header {


### PR DESCRIPTION
## Summary
- Wrap intro GIF with loader container and spinner
- Remove white background and shorten intro duration to 1.5s

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68956c82ac5883219648d9719f285eaf