### PR TITLE
Reset loader gif on refresh and fix link colors

### DIFF
--- a/catering.html
+++ b/catering.html
@@ -37,7 +37,7 @@
     
      <!-- Mobile Contact Bar -->
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="tel:+17739401632"><i class="fas fa-phone"  target="_blank" style="color: inherit;"></i> Call Us</a>
+        <a href="tel:+17739401632"><i class="fas fa-phone" target="_blank"></i> Call Us</a>
     </div>
     
     <main>
@@ -65,7 +65,7 @@
         <!-- Sub-footer section -->
         <div class="sub-footer">
             <p>&copy; Copyright 2024 | Developed by
-                <a href="https://SaasProductized.com" target="_blank" style="color: white;">SaaS Productized Co</a>. | All Rights Reserved
+                <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co</a>. | All Rights Reserved
             </p>
         </div>
     </footer>
@@ -74,6 +74,10 @@
         document.addEventListener('DOMContentLoaded', function() {
             const intro = document.getElementById('intro-animation');
             if (intro) {
+                const gif = intro.querySelector('img');
+                if (gif) {
+                    gif.src = gif.src.split('?')[0] + '?t=' + new Date().getTime();
+                }
                 intro.style.display = 'flex';
             }
         });

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     
          <!-- Mobile Contact Bar -->
 <div id="mobile-bar" class="mobile-contact-bar">
-    <a href="tel:+17739401632" style="color: white; text-decoration: none;"><i class="fas fa-phone" target="_blank"></i> Call Us</a>
+    <a href="tel:+17739401632"><i class="fas fa-phone" target="_blank"></i> Call Us</a>
 </div>
 <main>
 <br>
@@ -160,7 +160,7 @@
     <!-- Sub-footer section -->
     <div class="sub-footer">
         <p>&copy; Copyright 2024 | Developed by 
-            <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | All Rights Reserved
+            <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co</a>. | All Rights Reserved
         </p>
     </div>
 </footer>
@@ -168,6 +168,10 @@
         document.addEventListener('DOMContentLoaded', function() {
             const intro = document.getElementById('intro-animation');
             if (intro) {
+                const gif = intro.querySelector('img');
+                if (gif) {
+                    gif.src = gif.src.split('?')[0] + '?t=' + new Date().getTime();
+                }
                 intro.style.display = 'flex';
             }
         });

--- a/style.css
+++ b/style.css
@@ -304,6 +304,10 @@ footer {
     margin: 0; /* Remove any margin */
 }
 
+.sub-footer a {
+    color: black;
+}
+
 .social-icons {
     background-color: #333; /* Gray color */
     display: flex;
@@ -475,6 +479,11 @@ footer {
     justify-content: space-around;
     padding: 12px 0;
     z-index: 950; /* Ensure it is above other content */
+}
+
+.mobile-contact-bar a {
+    color: white;
+    text-decoration: none;
 }
 
 /* Padding for body to prevent the mobile contact bar from covering content */


### PR DESCRIPTION
## Summary
- Reload loader gif on each page load so intro animation always plays
- Style mobile contact bar links in white and footer attribution link in black for better visibility

## Testing
- `npx htmlhint index.html catering.html` *(fails: 403 Forbidden fetching htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68962aaa365483219f7b708f88d1cc63