### PR TITLE
Ensure mobile 'Call Us' link uses white and fix About Us map width

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
         
     <br>
     <br>
-    <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d11895.83981496484!2d-87.7279591!3d41.8076231!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x880e31f17b239cf9%3A0x8b8e75c0e61156c3!2sQuerrepario!5e0!3m2!1sen!2sus!4v1727910802051!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+    <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d11895.83981496484!2d-87.7279591!3d41.8076231!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x880e31f17b239cf9%3A0x8b8e75c0e61156c3!2sQuerrepario!5e0!3m2!1sen!2sus!4v1727910802051!5m2!1sen!2sus" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
 </div>
 </div>
 

--- a/style.css
+++ b/style.css
@@ -387,12 +387,19 @@ footer {
     text-align: center;
     margin: 0 auto;
     max-width: 800px; /* Adjust the max-width as needed */
-	size:24pt;
-	border: 1px solid #ccc; 
+        size:24pt;
+        border: 1px solid #ccc;
     font-size: 19pt;
     font-style: italic;
-	
 
+
+}
+
+#about-us iframe {
+    width: 100%;
+    max-width: 600px;
+    display: block;
+    margin: 0 auto;
 }
 
 .about-us-box {
@@ -482,7 +489,14 @@ footer {
 }
 
 .mobile-contact-bar a {
-    color: white;
+    color: white !important;
+    text-decoration: none;
+}
+
+.mobile-contact-bar a:visited,
+.mobile-contact-bar a:hover,
+.mobile-contact-bar a:active {
+    color: white !important;
     text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- Keep mobile contact bar 'Call Us' link white across all states on every page
- Center and scale About Us map responsively within page width

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68962d7bd63883219b617e5c3615bfd1