### PR TITLE
Align review stars closer to header logo

### DIFF
--- a/style.css
+++ b/style.css
@@ -78,7 +78,7 @@ header img#logo {
 .google-reviews {
     text-align: center;
     font-size: 0.8rem;
-    margin-top: 4px;
+    margin-top: -8px; /* Move stars closer to the logo */
 }
 
 .google-reviews .review-link {


### PR DESCRIPTION
## Summary
- move Google Reviews star widget up to sit near the logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898fd069eac8321bb350480b04b4bd2