### PR TITLE
Adjust star widget alignment in header

### DIFF
--- a/style.css
+++ b/style.css
@@ -78,7 +78,7 @@ header img#logo {
 .google-reviews {
     text-align: center;
     font-size: 0.8rem;
-    margin-top: -8px; /* Move stars closer to the logo */
+    margin-top: -35px; /* Move stars closer to the logo */
 }
 
 .google-reviews .review-link {


### PR DESCRIPTION
## Summary
- Bring Google review stars closer to the logo by increasing the widget's negative top margin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689900cd418c8321b0a5ceda1ad78c25