### PR TITLE
Restore full-width nav bar and stretch decorative lines

### DIFF
--- a/catering.html
+++ b/catering.html
@@ -15,9 +15,7 @@
         </div>
     </div>
     <header class="sticky-header"> <!-- Added sticky header class -->
-        <div class="squigly">
-            <img src="squigly.png" alt="Arte" />
-        </div>
+        <div class="squigly"></div>
         <a href="index.html"><img src="querrepario_logo.png" alt="Querrepario Mexican Kitchen Logo" id="logo"></a>
         <div class="google-reviews">
             <a class="review-link" href="https://share.google/zbRni4jmLCZ1K6LQN" target="_blank" rel="noopener">
@@ -32,9 +30,7 @@
                 <span class="rating-count">(27 Ratings &amp; Reviews)</span>
             </a>
         </div>
-        <div class="squigly">
-            <img src="squigly.png" alt="Arte" />
-        </div>
+        <div class="squigly"></div>
         <nav>
             <ul>
                 <li><a href="https://qrcodes.pro/8ZyNFQ#Mexican%20Kitchen" target="_blank">Menu</a></li>
@@ -70,9 +66,7 @@
             <a href="https://www.tiktok.com/@querrepariomexkitchen" target="_blank"><i class="fab fa-tiktok"></i></a>
         </div>
         <br>
-        <div class="squigly">
-            <img src="squigly.png" alt="Arte" />
-        </div>
+        <div class="squigly"></div>
         <p>&copy; 2023 Querrepario Mexican Kitchen</p>
 
         <!-- Sub-footer section -->

--- a/index.html
+++ b/index.html
@@ -15,9 +15,7 @@
         </div>
     </div>
     <header class="sticky-header">
-	<div class="squigly">
-    <img src="squigly.png" alt="Arte" />
-</div>
+        <div class="squigly"></div>
         <a href="index.html">
         <img src="querrepario_logo.png" alt="Querrepario Mexican Kitchen Logo" id="logo">
         </a>
@@ -34,9 +32,7 @@
                 <span class="rating-count">(27 Ratings &amp; Reviews)</span>
             </a>
         </div>
-        <div class="squigly">
-    <img src="squigly.png" alt="Arte" />
-</div>
+        <div class="squigly"></div>
 <br>
         <nav>
             <ul>
@@ -106,13 +102,10 @@
 
 <div id="about-us">
     <p>Querrepario Mexican Kitchen is a modern culinary establishment located in the heart of the Gage Park neighborhood in Chicago, Illinois. We are renowned for our authentic Mexican cuisine deeply rooted in the traditions of Olinalá, Guerrero, Mexico...</p>
-	<div class="squigly2">
-    <img src="squigly2.png" alt="Arte" />
-        
+        <div class="squigly2"></div>
     <br>
     <br>
     <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d11895.83981496484!2d-87.7279591!3d41.8076231!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x880e31f17b239cf9%3A0x8b8e75c0e61156c3!2sQuerrepario!5e0!3m2!1sen!2sus!4v1727910802051!5m2!1sen!2sus" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-</div>
 </div>
 
 
@@ -165,9 +158,7 @@
     </div>
     <br>
     <br>
-    <div class="squigly">
-        <img src="squigly.png" alt="Arte" />
-    </div>
+        <div class="squigly"></div>
     <p>&copy; 2023 Querrepario Mexican Kitchen</p>
 
     <!-- Sub-footer section -->

--- a/style.css
+++ b/style.css
@@ -83,6 +83,9 @@ header img#logo {
     font-size: 0.8rem;
     margin-top: 8px;
     margin-bottom: 8px;
+    position: relative;
+    top: -30px;
+    z-index: 1100;
 }
 
 .google-reviews .review-link {
@@ -134,6 +137,7 @@ nav {
     display: flex;
     justify-content: center;
     box-sizing: border-box;
+    width: 100%;
 }
 
 nav ul {
@@ -200,21 +204,23 @@ header.sticky-header + nav {
     margin-top: 0;
 }
 
-/* Adjust the spacing between squigly images and logo */
-.squigly {
-    display: flex; /* Use flex to align items */
-    justify-content: center; /* Horizontally center the image */
-    margin: 0 auto; /* Center the squigly image container */
-    padding: 0; /* Remove any padding */
+/* Decorative squigly lines */
+.squigly,
+.squigly2 {
+    width: 100%;
+    height: 25px;
+    background-repeat: repeat-x;
+    background-position: center;
+    margin: 0 auto;
+    padding: 0;
 }
 
-.squigly img {
-    display: block; /* Ensure the squigly images are block-level */
-    margin: 5px auto; /* Center the image with spacing */
-    padding: 0; /* Remove extra padding */
-    width: auto; /* Ensure the image keeps its natural width */
-    height: auto; /* Ensure the image keeps its natural height */
-    max-width: 100%; /* Ensure the image scales properly on mobile */
+.squigly {
+    background-image: url('squigly.png');
+}
+
+.squigly2 {
+    background-image: url('squigly2.png');
 }
 
 /* Additional adjustments to reduce space between squigly images and logo */


### PR DESCRIPTION
## Summary
- Force the gray navigation bar to span the full screen width on all devices
- Raise the Google review star widget and ensure it sits above the logo
- Replace inline squigly images with repeating CSS backgrounds for full-width decorative lines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689908375540832187be1885e5968f6c